### PR TITLE
chg: adding elastic host + name as environment variable

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -60,10 +60,10 @@ auth = {
 
 # A list of known hosts
 hosts = [
-  #{
-  #  host = "http://localhost:9200"
-  #  name = "Some Cluster"
-  #},
+  {
+    host = "{?ELASTIC_HOST}"
+    name = "{?ELASTIC_NAME}"
+  },
   # Example of host with authentication
   #{
   #  host = "http://some-authenticated-host:9200"


### PR DESCRIPTION
Would be great for out-of-the-box docker deployments without needing to fork, modify, and rebuild.